### PR TITLE
Simplification of FetchValueCommand

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,4 +7,6 @@ var (
 	ErrAddressRequired error = errors.New("RemoteAddress is required in options")
 	ErrCannotRead      error = errors.New("cannot read from a non-active or closed connection")
 	ErrCannotWrite     error = errors.New("cannot write to a non-active or closed connection")
+	ErrBucketRequired  error = errors.New("bucket is required")
+	ErrKeyRequired     error = errors.New("key is required")
 )

--- a/kv_commands_i_test.go
+++ b/kv_commands_i_test.go
@@ -24,7 +24,7 @@ func TestFetchANotFoundFromRiakUsingDefaultBucketType(t *testing.T) {
 	var err error
 	var cmd Command
 	builder := NewFetchValueCommandBuilder()
-	if cmd, err = builder.WithBucket(testBucketName).WithKey("my_key1").Build(); err != nil {
+	if cmd, err = builder.WithBucket(testBucketName).WithKey("notfound_key").Build(); err != nil {
 		t.Fatal(err.Error())
 	}
 	if err = cluster.Execute(cmd); err != nil {
@@ -49,6 +49,54 @@ func TestFetchANotFoundFromRiakUsingDefaultBucketType(t *testing.T) {
 		}
 		if expected, actual := 0, len(rsp.Values); expected != actual {
 			t.Errorf("expected %v, got %v", expected, actual)
+		}
+	} else {
+		t.FailNow()
+	}
+}
+
+func TestFetchAValueFromRiakUsingDefaultBucketType(t *testing.T) {
+	var err error
+	var cmd Command
+	builder := NewFetchValueCommandBuilder()
+	if cmd, err = builder.WithBucket(testBucketName).WithKey("my_key1").Build(); err != nil {
+		t.Fatal(err.Error())
+	}
+	if err = cluster.Execute(cmd); err != nil {
+		t.Fatal(err.Error())
+	}
+	if fvc, ok := cmd.(*FetchValueCommand); ok {
+		if fvc.Response == nil {
+			t.Errorf("expected non-nil Response")
+		}
+		rsp := fvc.Response
+		if expected, actual := false, rsp.IsNotFound; expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := false, rsp.IsUnchanged; expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		if rsp.VClock == nil {
+			t.Errorf("expected non-nil VClock")
+		}
+		if rsp.Values == nil {
+			t.Errorf("expected non-nil Values")
+		}
+		if expected, actual := 1, len(rsp.Values); expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		object := rsp.Values[0]
+		if expected, actual := "this is a value in Riak", string(object.Value); expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := "text/plain", object.ContentType; expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		if object.Charset != "" {
+			t.Errorf("expected empty Charset")
+		}
+		if object.ContentEncoding != "" {
+			t.Errorf("expected empty ContentEncoding")
 		}
 	} else {
 		t.FailNow()

--- a/kv_commands_test.go
+++ b/kv_commands_test.go
@@ -13,34 +13,6 @@ import (
 var vclock = bytes.NewBufferString("vclock123456789")
 var vclockBytes = vclock.Bytes()
 
-func TestBuildRpbGetReqCorrectlyViaOptions(t *testing.T) {
-	fetchValueCommandOptions := &FetchValueCommandOptions{
-		BucketType:          "bucket_type",
-		Bucket:              "bucket_name",
-		Key:                 "key",
-		R:                   3,
-		Pr:                  1,
-		BasicQuorum:         true,
-		NotFoundOk:          true,
-		IfNotModified:       vclockBytes, // TODO pb is IfModified?
-		HeadOnly:            true,
-		ReturnDeletedVClock: true,
-		Timeout:             time.Second * 20,
-		SloppyQuorum:        true,
-		NVal:                4,
-	}
-	fetchValueCommand, err := NewFetchValueCommand(fetchValueCommandOptions)
-
-	protobuf, err := fetchValueCommand.constructPbRequest()
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if protobuf == nil {
-		t.FailNow()
-	}
-	validateRpbGetReq(t, protobuf)
-}
-
 func TestBuildRpbGetReqCorrectlyViaBuilder(t *testing.T) {
 	builder := NewFetchValueCommandBuilder().
 		WithBucketType("bucket_type").
@@ -117,13 +89,12 @@ func validateRpbGetReq(t *testing.T, protobuf proto.Message) {
 }
 
 func TestBuildRpbGetReqCorrectlyWithDefaults(t *testing.T) {
-	fetchValueCommandOptions := &FetchValueCommandOptions{
-		Bucket: "bucket_name",
-		Key:    "key",
-	}
-	fetchValueCommand, err := NewFetchValueCommand(fetchValueCommandOptions)
+	builder := NewFetchValueCommandBuilder().
+		WithBucket("bucket_name").
+		WithKey("key")
+	cmd, err := builder.Build()
 
-	protobuf, err := fetchValueCommand.constructPbRequest()
+	protobuf, err := cmd.constructPbRequest()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -147,26 +118,22 @@ func TestBuildRpbGetReqCorrectlyWithDefaults(t *testing.T) {
 			t.Errorf("expected nil value")
 		}
 		if rpbGetReq.NotfoundOk != nil {
-			// TODO
-			t.Logf("expected nil value")
+			t.Error("expected nil value")
 		}
 		if rpbGetReq.IfModified != nil {
 			t.Errorf("expected nil value")
 		}
 		if rpbGetReq.Head != nil {
-			// TODO
-			t.Logf("expected nil value")
+			t.Error("expected nil value")
 		}
 		if rpbGetReq.Deletedvclock != nil {
-			// TODO
-			t.Logf("expected nil value")
+			t.Error("expected nil value")
 		}
 		if rpbGetReq.Timeout != nil {
 			t.Errorf("expected nil value")
 		}
 		if rpbGetReq.SloppyQuorum != nil {
-			// TODO
-			t.Logf("expected nil value")
+			t.Error("expected nil value")
 		}
 		if rpbGetReq.NVal != nil {
 			t.Errorf("expected nil value")


### PR DESCRIPTION
This change would require that users use the builder. It has the benefit of correctly keeping nullable RPB options like `BasicQuorum` set to `nil` in the message rather than `false` as would be the case if the options struct is used.