### PR TITLE
Allow API user to pass PB struct directly, bypassing the builder.

### DIFF
--- a/kv_commands.go
+++ b/kv_commands.go
@@ -25,6 +25,13 @@ type FetchValueCommand struct {
 	resolver ConflictResolver
 }
 
+func NewFetchValueCommand(pb *rpbRiakKV.RpbGetReq, resolver ConflictResolver) *FetchValueCommand {
+	return &FetchValueCommand{
+		protobuf: pb,
+		resolver: resolver,
+	}
+}
+
 func (cmd *FetchValueCommand) Name() string {
 	return "FetchValue"
 }


### PR DESCRIPTION
Kind of works like this:

https://github.com/riaken/riaken-core/blob/master/object.go#L39